### PR TITLE
Do not match separator in the beginning of street address

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -895,7 +895,7 @@ full_street = r"""
     (?:
         (?P<full_street>
             (?:
-                (?P<po_box_b>{po_box})?\,?\s?
+                (?P<po_box_b>{po_box}\,?\s?)?
                 {street_number}
                 (?:
                     (?:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -89,7 +89,7 @@ def test_parse_address():
 
     ap = parser.AddressParser(country="US")
     test_address = (
-        "xxx 225 E. John Carpenter Freeway, " + "Suite 1500 Irving, Texas 75062 xxx"
+        "xxx, 225 E. John Carpenter Freeway, " + "Suite 1500 Irving, Texas 75062 xxx"
     )
 
     addresses = ap.parse(test_address)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -89,10 +89,23 @@ def test_parse_address():
 
     ap = parser.AddressParser(country="US")
     test_address = (
-        "xxx, 225 E. John Carpenter Freeway, " + "Suite 1500 Irving, Texas 75062 xxx"
+        "xxx 225 E. John Carpenter Freeway, " + "Suite 1500 Irving, Texas 75062 xxx"
     )
 
     addresses = ap.parse(test_address)
+    assert (
+        addresses[0].full_address
+        == "225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062"
+    )
+
+
+def test_do_not_match_separator_start():
+    ap = parser.AddressParser(country="US")
+    test_address = (
+        "xxx, 225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062 xxx"
+    )
+    addresses = ap.parse(test_address)
+    assert addresses[0].match_start == 5
     assert (
         addresses[0].full_address
         == "225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062"

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -418,6 +418,8 @@ def test_po_box_positive(input, expected):
         ("78 SE Criket", True),
         ("P.O. BOX 41256, One Velvet Drive", True),
         ("666 Hell ST PMB 29700", True),
+        # positive assertions
+        (", 666 Hell ST PMB 29700", False),
     ],
 )
 def test_full_street_positive(input, expected):

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -418,7 +418,7 @@ def test_po_box_positive(input, expected):
         ("78 SE Criket", True),
         ("P.O. BOX 41256, One Velvet Drive", True),
         ("666 Hell ST PMB 29700", True),
-        # positive assertions
+        # negative assertions
         (", 666 Hell ST PMB 29700", False),
     ],
 )


### PR DESCRIPTION
We are matching the address like `, 1900 HAYES ST, GRAND HAVEN, MI 49417` - the separator in the beginning should not be matched.