### PR TITLE
Make US state optional

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -1102,10 +1102,12 @@ full_address = r"""
                     {full_street} {div}
                     {phone_number}? {div}
                     {city} [\, -]{{1,2}}
-                    (?:{region1} {div})?
                     (?:
-                        (?:\ ?,?{postal_code}?(\ ?,?{country})?)
-                    )
+                        {region1} {div}
+                        | 
+                        {postal_code} {div}
+                    ){{1,2}}
+                    {country}?
                 )
                 """.format(
     full_street=full_street,

--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -96,7 +96,7 @@ street_number = r"""(?P<street_number>
                         ){from_to}
                         |
                         (?:\d{from_to}
-                            (?:\ ?\-?\ ?(?:\d{from_to}|[A-Z]))?\ 
+                            (?:\ ?\-?\ ?(?:\d{from_to}|(?:\-\ ?[A-Z])))?\ 
                         )
                     )
                 """.format(
@@ -1102,7 +1102,7 @@ full_address = r"""
                     {full_street} {div}
                     {phone_number}? {div}
                     {city} [\, -]{{1,2}}
-                    {region1} {div}
+                    (?:{region1} {div})?
                     (?:
                         (?:\ ?,?{postal_code}?(\ ?,?{country})?)
                     )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -82,34 +82,47 @@ def test_combine_results():
     assert ap._combine_results(raw_dict) == {"test_one": 1, "test_two": 2}
 
 
-def test_parse_address():
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        ("No address here", None),
+        (
+            "xxx, 225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062 xxx",
+            {
+                "street_number": "225",
+                "street_name": "E. John Carpenter",
+                "street_type": "Freeway",
+                "occupancy": "Suite 1500",
+                "city": "Irving",
+                "region1": "Texas",
+                "postal_code": "75062",
+                "full_address": (
+                    "225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062"
+                ),
+            },
+        ),
+        (
+            "1300 E MOUNT GARFIELD ROAD, NORTON SHORES 49441",
+            {
+                "street_number": "1300",
+                "street_name": "E MOUNT GARFIELD",
+                "street_type": "ROAD",
+                "city": "NORTON SHORES",
+                "region1": None,
+                "postal_code": "49441",
+                "full_address": ("1300 E MOUNT GARFIELD ROAD, NORTON SHORES 49441"),
+            },
+        ),
+    ],
+)
+def test_parse_address(input: str, expected):
     ap = parser.AddressParser(country="US")
-    result = ap.parse("No address here")
-    assert not result
-
-    ap = parser.AddressParser(country="US")
-    test_address = (
-        "xxx 225 E. John Carpenter Freeway, " + "Suite 1500 Irving, Texas 75062 xxx"
-    )
-
-    addresses = ap.parse(test_address)
-    assert (
-        addresses[0].full_address
-        == "225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062"
-    )
-
-
-def test_do_not_match_separator_start():
-    ap = parser.AddressParser(country="US")
-    test_address = (
-        "xxx, 225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062 xxx"
-    )
-    addresses = ap.parse(test_address)
-    assert addresses[0].match_start == 5
-    assert (
-        addresses[0].full_address
-        == "225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062"
-    )
+    if result := ap.parse(input):
+        expected = expected or {}
+        for key in expected:
+            assert getattr(result[0], key) == expected[key]
+    else:
+        assert expected is None
 
 
 def test_parse_po_box():

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -528,6 +528,7 @@ def test_full_street_positive(input, expected):
         ("ONE FOR ANY DIRECT, INDIRECT, IN", False),
         ("2 TRACTOR HEAD Actros MP", False),
         ("00 Straight Fit Jean, USA", False),
+        ("123 Curvy Way, Littleville, USA", False),
     ],
 )
 def test_full_address(input, expected):

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -130,6 +130,7 @@ def test_thousand(input, expected):
         ("ONE THousszz22and FIFTY and four onde", False),
         ("ONE one oNe and onE Three", False),
         # negative assertions (numbers)
+        ("1000 E ", False),
         ("536233", False),
         ("111111", False),
         ("1111ss11", False),
@@ -153,6 +154,7 @@ def test_street_number(input, expected):
         ("Eudailey-Covington", True),
         ("Smith’s mill road", True),
         ("Smith's mill road", True),
+        ("E MOUNT GARFIELD ROAD", True),
         # negative assertions
         ("Northeast Kentucky Industrial Maple ", False),
         ("a", False),
@@ -506,6 +508,7 @@ def test_full_street_positive(input, expected):
         ("23 Awesome Street *851-234-2567, Austin Tx 78755", True),
         ("POST OFFICE BOX 123, Austin TX 78755", True),
         ("1 MEGA CENTER, MegaCity, MICH.49423-9576", True),
+        ("1300 E MOUNT GARFIELD ROAD, NORTON SHORES 49441", True),
         # negative assertions
         ("85 STEEL REGULAR SHAFT - NE", False),
         ("3 STRUCTURE WITH PE", False),


### PR DESCRIPTION
MyADP sometimes don't provide the state in the address: 
<img width="290" alt="Screenshot 2023-06-22 at 12 14 40" src="https://github.com/argyle-engineering/pyap/assets/51202985/e4bdf044-9f70-4a0c-b013-eedfef4034b1">

This PR:
- makes US state optional, but always requires the state or zip code to be present
- requires the street number to be separated by a "-" from the letter
- refactor/add some unit tests