### PR TITLE
Make city matcher sloppy

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -1080,7 +1080,7 @@ region1 = r"""
 # TODO: doesn't catch cities containing French characters
 city = r"""
         (?P<city>
-            [A-Za-z]{1}[a-zA-Z\ \-\'\.]{2,20}
+            [A-Za-z]{1}[a-zA-Z\ \-\'\.]{2,20}?
         )
         """
 
@@ -1101,13 +1101,13 @@ full_address = r"""
                 (?P<full_address>
                     {full_street} {div}
                     {phone_number}? {div}
-                    {city} [\, -]{{1,2}}
+                    {city}
                     (?:
-                        {region1} {div}
+                        [\, -]{{1,2}} {region1} (?![A-Za-z])
                         | 
-                        {postal_code} {div}
+                        [\, -]{{0,3}} {postal_code}
                     ){{1,2}}
-                    {country}?
+                    {div} {country}?
                 )
                 """.format(
     full_street=full_street,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -113,6 +113,18 @@ def test_combine_results():
                 "full_address": ("1300 E MOUNT GARFIELD ROAD, NORTON SHORES 49441"),
             },
         ),
+        (
+            "7601 Penn Avenue South, Richfield MN 55423",
+            {
+                "street_number": "7601",
+                "street_name": "Penn",
+                "street_type": "Avenue",
+                "post_direction": "South",
+                "city": "Richfield",
+                "region1": "MN",
+                "postal_code": "55423",
+            },
+        ),
     ],
 )
 def test_parse_address(input: str, expected):


### PR DESCRIPTION
- Makes city matcher sloppy - otherwise we match it too late, capturing the state inside
- Adds negative look-ahead for the state matcher to reject the following non-matched letters.