### PR TITLE
Tinker suite matcher

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -751,7 +751,7 @@ def street_type_list_to_regex(street_type_list):
     # Use \b to check that there are word boundaries before and after the street type
     # Optionally match zero to two of " ", ",", or "." after the street name
     street_types = street_types.replace("|", r"\b{div}|\b")
-    street_types = r"\b" + street_types + r"\b{div}"
+    street_types = r"\b" + r"(?:" + street_types + r")" + r"\b\.?(?:[\,\ ]|$)"
     return street_types.format(
         div=r"[\.\ ,]{0,2}",
     )
@@ -835,7 +835,7 @@ occupancy = r"""
                     (?:
                         (?:
                             # Suite
-                            [Ss][Uu][Ii][Tt][Ee]\ |[Ss][Tt][Ee]\.?\ 
+                            [Ss][Uu][Ii][Tt][Ee]\ |[Ss][Tt][Ee]?[\.\ ]{1,2}
                             |
                             # Apartment
                             [Aa][Pp][Tt]\.?\ |[Aa][Pp][Aa][Rr][Tt][Mm][Ee][Nn][Tt]\ 

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -294,6 +294,7 @@ def test_building(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("ST.8-520", True),
         ("suite 900 ", True),
         ("Suite #2 ", True),
         ("suite #218 ", True),
@@ -370,6 +371,7 @@ def test_po_box_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("3525 PIEDMONT RD. NE ST.8-520", True),
         ("600 HIGHWAY 32 EAST,", True),
         ("9652 Loiret Boulevard", True),
         ("101 MacIntosh Boulevard", True),


### PR DESCRIPTION
Here `ST.8-520` probably refers to a Suite: 
<img width="334" alt="Screenshot 2023-07-14 at 18 55 33" src="https://github.com/argyle-engineering/pyap/assets/51202985/c83f8961-1688-490f-80d5-30ce4abf3d0c">

We adjust the occupancy and street type matchers to handle this properly
