### PR TITLE
Fix misc edge cases

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -112,13 +112,15 @@ Regexp for matching street name.
 In example below:
 "Hoover Boulevard": "Hoover" is a street name
 """
-street_name = r"""(?P<street_name>
-                  [a-zA-Z0-9\ \.\-\'\’]{3,31}  # Seems like the longest US street is
-                                         # 'Northeast Kentucky Industrial Parkway'
-                                         # https://atkinsbookshelf.wordpress.com/tag/longest-street-name-in-us/
-                 )
-              """
-
+# Seems like the longest US street is
+# 'Northeast Kentucky Industrial Parkway'
+# https://atkinsbookshelf.wordpress.com/tag/longest-street-name-in-us/
+# On the other hand, there are streets like "Ed Drive".
+street_name = r"""
+            (?P<street_name>
+                [a-zA-Z0-9\ \.\-\'\’]{3,31}|[a-zA-Z]{2}(?=\ [a-zA-Z])
+            )
+"""
 
 interstate_specs = [
     r"Service\ Road",
@@ -849,7 +851,7 @@ occupancy = r"""
                     (?:
                         (?:
                             # Suite
-                            [Ss][Uu][Ii][Tt][Ee]\ |[Ss][Tt][Ee]?[\.\ ]{1,2}
+                            [Ss][Uu][Ii][Tt][Ee]\,?\ |[Ss][Tt][Ee]?[\.\ ]{1,2}
                             |
                             # Apartment
                             [Aa][Pp][Tt]\.?\ |[Aa][Pp][Aa][Rr][Tt][Mm][Ee][Nn][Tt]\ 
@@ -927,7 +929,7 @@ full_street = r"""
                         [A-z0-9\.\-]{{2,31}}
                     )
                 )\,?\s?
-                (?:(?<!,\ ){post_direction}[,\s])?
+                (?:{post_direction}[,\s])?
                 {floor}?\,?\s?
                 {building}?\,?\s?
                 {occupancy}?\,?\s?

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -371,6 +371,7 @@ def test_po_box_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("3821 ED DR", True),
         ("3525 PIEDMONT RD. NE ST.8-520", True),
         ("140 EAST 45TH, ST, 28TH FLOOR", True),
         ("600 HIGHWAY 32 EAST,", True),
@@ -452,6 +453,9 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("3821 ED DR, RALEIGH, NC 27612", True),
+        ("213 WEST 35TH STREET SUITE, 400, NEW YORK, NY", True),
+        ("326 33RD AVE., EAST, SEATTLE, WA 98112", True),
         ("242 N AVENUE 25 SUITE 300, LOS ANGELES, CA 90031", True),
         ("123 Very Nice Street, Ulm, AR 12345", True),
         ("16444 N 91ST ST BLDG H, SCOTTSDALE, AZ 85260", True),


### PR DESCRIPTION
Support these edge cases:
- comma after "suite"
<img width="411" alt="Screenshot 2023-07-17 at 17 54 01" src="https://github.com/argyle-engineering/pyap/assets/51202985/b86d9030-3e2a-49b4-ac87-f25480f0ebd4">

- post direction following a comma
<img width="195" alt="Screenshot 2023-07-17 at 17 19 54" src="https://github.com/argyle-engineering/pyap/assets/51202985/4464cb51-372b-45a9-92f0-e642e6099d4e">

- very short street name
<img width="460" alt="Screenshot 2023-07-18 at 11 48 09" src="https://github.com/argyle-engineering/pyap/assets/51202985/34291b0e-267d-416f-bf43-9e59258dc058">

