### PR TITLE
Consider newlines as valid separators for address parts

### DIFF
--- a/pyap/parser.py
+++ b/pyap/parser.py
@@ -105,14 +105,14 @@ class AddressParser:
     @staticmethod
     def _normalize_string(text: str) -> str:
         """Prepares incoming text for parsing:
-        removes excessive spaces, tabs, newlines, etc.
+        removes excessive spaces, tabs, etc.
+        We should keep the newlines as they are
+        good indicators for limits of elements.
         """
         conversion = {
-            # newlines
-            r"\r*(\n\r*)+": ", ",
-            r"\s*(\,\s*)+": ", ",
+            r"[\ \t]*(\,[\ \t]*)+": ", ",
             # replace excessive empty spaces
-            r"\s+": " ",
+            r"\ +": " ",
             # convert all types of hyphens/dashes to a
             # simple old-school dash
             # from http://utf8-chartable.de/unicode-utf8-table.pl?

--- a/pyap/source_GB/data.py
+++ b/pyap/source_GB/data.py
@@ -68,9 +68,9 @@ thousand = r"""
                                 )
 """
 
-part_divider = r"(?: [\,\ \.\-]{0,3}\,[\,\ \.\-]{0,3} )"
+part_divider = r"(?:[\,\ \.\-]{0,3}[\,\n][\,\ \.\-]{0,3})"
 space_pattern = (
-    r"(?: [\ \t]{1,3} )"  # TODO: use \b for word boundary and \s for whitespace
+    r"(?:[\ \t]{1,3})"  # TODO: use \b for word boundary and \s for whitespace
 )
 
 """

--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -146,7 +146,7 @@ interstate_street_type = r"""
     optional_interstate_specs=str_list_to_upper_lower_regex(interstate_specs)
 )
 
-highway_re = r"""(?:[Hh][Ii][Gg][Hh][Ww][Aa][Yy]\s+\d{1,4})"""
+highway_re = r"""(?:[Hh][Ii][Gg][Hh][Ww][Aa][Yy]\ +\d{1,4})"""
 
 post_direction_re = r"""
                 (?:
@@ -178,6 +178,7 @@ single_street_name_list = [
     "Broadway",
     "Highpoint",
     "Parkway",
+    r"Black\ Hou?rse",
 ]
 
 
@@ -904,7 +905,7 @@ occupancy = r"""
                     (?:
                         \#?\ ?[0-9]{1,4}
                     )
-                )(:?[\ \,]|$)
+                )(:?[\s\,]|$)
             )
             """
 
@@ -949,11 +950,12 @@ full_street = r"""
                         {post_direction_re}\ 
                         [A-z0-9\.\-]{{2,31}}
                     )
-                )\,?\s?
-                (?:{post_direction}[,\s])?
-                {floor}?\,?\s?
-                {building}?\,?\s?
-                {occupancy}?\,?\s?
+                )\,?\ ?
+                (?:{post_direction}\b\,?)?
+                \s?
+                {floor}?\,?\ ?
+                {building}?\,?\ ?
+                {occupancy}?\,?\ ?
                 (?P<po_box_a>{po_box})?
             )
             |
@@ -1159,7 +1161,7 @@ full_address = r"""
                 )
                 """.format(
     full_street=full_street,
-    div=r"[\, -]{,2}",
+    div=r"[\,\s-]{,2}",
     city=city,
     region1=region1,
     country=country,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -69,9 +69,9 @@ def test_country_detection_missing():
 
 def test_normalize_string():
     ap = parser.AddressParser(country="US")
-    raw_string = """\n The  quick      \t, brown fox      jumps over the lazy dog,
-    ‐ ‑ ‒ – — ―
-    """
+    raw_string = (
+        """, The  quick      \t, brown fox      jumps over the lazy dog, ‐ ‑ ‒ – — ―,"""
+    )
     clean_string = ", The quick, brown fox jumps over the lazy dog, - - - - - -, "
     assert ap._normalize_string(raw_string) == clean_string
 
@@ -86,6 +86,19 @@ def test_combine_results():
     "input,expected",
     [
         ("No address here", None),
+        (
+            "696 BEAL PKWY NW\nFT WALTON BCH FL 32547",
+            {
+                "street_number": "696",
+                "street_name": "BEAL",
+                "street_type": "PKWY",
+                "post_direction": "NW",
+                "city": "FT WALTON BCH",
+                "region1": "FL",
+                "postal_code": "32547",
+                "full_address": ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547"),
+            },
+        ),
         (
             "xxx, 225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062 xxx",
             {
@@ -154,8 +167,8 @@ def test_parse_address(input: str, expected):
     ap = parser.AddressParser(country="US")
     if result := ap.parse(input):
         expected = expected or {}
-        for key in expected:
-            assert getattr(result[0], key) == expected[key]
+        received = {key: getattr(result[0], key) for key in expected}
+        assert expected == received
     else:
         assert expected is None
 

--- a/tests/test_parser_gb.py
+++ b/tests/test_parser_gb.py
@@ -16,7 +16,8 @@ def execute_matching_test(input, expected, pattern):
     match = utils.match(pattern, input, re.VERBOSE)
     is_found = match is not None
     if expected:
-        assert is_found == expected and match.group(0) == input  # type: ignore
+        assert is_found == expected
+        assert match.group(0) == input  # type: ignore
     else:
         assert (is_found == expected) or (match.group(0) != input)  # type: ignore
 
@@ -480,7 +481,7 @@ def test_country(input, expected):
     "input,expected",
     [
         # positive assertions
-        ("11-59 High Road, East Finchley London, N2 8AW", True),
+        ("11-59 High Road\nEast Finchley London\nN2 8AW, UK", True),
         ("88 White parkway, Stanleyton, L2 3DB", True),
         ("Studio 96D, Graham roads, Westtown, L1A 3GP, Great Britain", True),
         ("01 Brett mall, Lake Donna, W02 3JQ", True),

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -387,7 +387,10 @@ def test_po_box_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("1806 Dominion Way Ste B", True),
+        ("696 BEAL PKWY", True),
         ("3821 ED DR", True),
+        ("8025 BLACK HOURSE", True),
         ("3525 PIEDMONT RD. NE ST.8-520", True),
         ("140 EAST 45TH, ST, 28TH FLOOR", True),
         ("600 HIGHWAY 32 EAST,", True),
@@ -469,6 +472,8 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("8025 BLACK HORSE\nSTE 300\nPLEASANTVILLE NJ 08232", True),
+        ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547", True),
         ("2633 Camino Ramon Ste. 400 San Ramon, CA 94583-2176", True),
         ("2951 El Camino Real Palo Alto, CA 94306", True),
         ("3821 ED DR, RALEIGH, NC 27612", True),


### PR DESCRIPTION
Raw addresses usually come from a list of lines. We should try to preserve the meaning of a newline character when parsing - newline cannot appear in the middle of a street name or a city name