### PR TITLE
Rework with newlines

### DIFF
--- a/pyap/parser.py
+++ b/pyap/parser.py
@@ -105,14 +105,14 @@ class AddressParser:
     @staticmethod
     def _normalize_string(text: str) -> str:
         """Prepares incoming text for parsing:
-        removes excessive spaces, tabs, newlines, etc.
+        removes excessive spaces, tabs, etc.
+        We should keep the newlines as they are
+        good indicators for limits of elements.
         """
         conversion = {
-            # newlines
-            r"\r*(\n\r*)+": ", ",
-            r"\s*(\,\s*)+": ", ",
+            r"[\ \t]*(\,[\ \t]*)+": ", ",
             # replace excessive empty spaces
-            r"\s+": " ",
+            r"\ +": " ",
             # convert all types of hyphens/dashes to a
             # simple old-school dash
             # from http://utf8-chartable.de/unicode-utf8-table.pl?

--- a/pyap/source_GB/data.py
+++ b/pyap/source_GB/data.py
@@ -68,9 +68,9 @@ thousand = r"""
                                 )
 """
 
-part_divider = r"(?: [\,\ \.\-]{0,3}\,[\,\ \.\-]{0,3} )"
+part_divider = r"(?:[\,\ \.\-]{0,3}[\,\n][\,\ \.\-]{0,3})"
 space_pattern = (
-    r"(?: [\ \t]{1,3} )"  # TODO: use \b for word boundary and \s for whitespace
+    r"(?:[\ \t]{1,3})"  # TODO: use \b for word boundary and \s for whitespace
 )
 
 """

--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -1155,7 +1155,7 @@ full_address = r"""
                     (?:
                         {part_div} {region1} (?![A-Za-z])
                         | 
-                        (?:{part_div}? {postal_code})
+                        (?:{part_div}|\-)? {postal_code}
                     ){{1,2}}
                     (?:{part_div} {country})?
                 )

--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -98,7 +98,7 @@ street_number = r"""(?P<street_number>
                             {ten_to_ninety}
                         ){from_to}
                         |
-                        (?:\b\d{from_to}(?:\ ?\-\ ?(?:\d{from_to}|[A-Z]))?\ )
+                        (?:\b\d{from_to}(?:\-(?:\d{from_to}|[A-Z]))?\ )
                     )
                 """.format(
     thousand=thousand,
@@ -932,7 +932,7 @@ phone_number = r"""
             )
             """
 
-part_div = r"(?:[\,\s]{1,2}|$)"  # allows for line breaks
+part_div = r"(?:[\,\s]{1,2}|\ \-\ |$)"  # allows for line breaks
 
 full_street = r"""
     (?:
@@ -1155,7 +1155,7 @@ full_address = r"""
                     (?:
                         {part_div} {region1} (?![A-Za-z])
                         | 
-                        (?:{part_div}|\ ?\-\ ?|(?<=\.)) {postal_code}
+                        (?:{part_div}? {postal_code})
                     ){{1,2}}
                     (?:{part_div} {country})?
                 )

--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -146,7 +146,7 @@ interstate_street_type = r"""
     optional_interstate_specs=str_list_to_upper_lower_regex(interstate_specs)
 )
 
-highway_re = r"""(?:[Hh][Ii][Gg][Hh][Ww][Aa][Yy]\s+\d{1,4})"""
+highway_re = r"""(?:[Hh][Ii][Gg][Hh][Ww][Aa][Yy]\ +\d{1,4})"""
 
 post_direction_re = r"""
                 (?:
@@ -178,6 +178,7 @@ single_street_name_list = [
     "Broadway",
     "Highpoint",
     "Parkway",
+    r"Black\ Hou?rse",
 ]
 
 
@@ -904,7 +905,7 @@ occupancy = r"""
                     (?:
                         \#?\ ?[0-9]{1,4}
                     )
-                )(:?[\ \,]|$)
+                )(:?[\s\,]|$)
             )
             """
 
@@ -949,11 +950,12 @@ full_street = r"""
                         {post_direction_re}\ 
                         [A-z0-9\.\-]{{2,31}}
                     )
-                )\,?\s?
-                (?:{post_direction}[,\s])?
-                {floor}?\,?\s?
-                {building}?\,?\s?
-                {occupancy}?\,?\s?
+                )\,?\ ?
+                (?:{post_direction}\b\,?)?
+                \s?
+                {floor}?\,?\ ?
+                {building}?\,?\ ?
+                {occupancy}?\,?\ ?
                 (?P<po_box_a>{po_box})?
             )
             |
@@ -1159,7 +1161,7 @@ full_address = r"""
                 )
                 """.format(
     full_street=full_street,
-    div=r"[\, -]{,2}",
+    div=r"[\,\s-]{,2}",
     city=city,
     region1=region1,
     country=country,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -87,6 +87,19 @@ def test_combine_results():
     [
         ("No address here", None),
         (
+            "2590 Elm Road NE - Warren, OH 44483",
+            {
+                "street_number": "2590",
+                "street_name": "Elm",
+                "street_type": "Road",
+                "post_direction": "NE",
+                "city": "Warren",
+                "region1": "OH",
+                "postal_code": "44483",
+                "full_address": "2590 Elm Road NE - Warren, OH 44483",
+            },
+        ),
+        (
             "899 HEATHROW PARK LN 02-2135\nLAKE MARY,FL 32746",
             {
                 "street_number": "899",
@@ -180,7 +193,7 @@ def test_parse_address(input: str, expected):
     if result := ap.parse(input):
         expected = expected or {}
         received = {key: getattr(result[0], key) for key in expected}
-        assert expected == received
+        assert received == expected
     else:
         assert expected is None
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -69,9 +69,9 @@ def test_country_detection_missing():
 
 def test_normalize_string():
     ap = parser.AddressParser(country="US")
-    raw_string = """\n The  quick      \t, brown fox      jumps over the lazy dog,
-    ‐ ‑ ‒ – — ―
-    """
+    raw_string = (
+        """, The  quick      \t, brown fox      jumps over the lazy dog, ‐ ‑ ‒ – — ―,"""
+    )
     clean_string = ", The quick, brown fox jumps over the lazy dog, - - - - - -, "
     assert ap._normalize_string(raw_string) == clean_string
 
@@ -86,6 +86,19 @@ def test_combine_results():
     "input,expected",
     [
         ("No address here", None),
+        (
+            "696 BEAL PKWY NW\nFT WALTON BCH FL 32547",
+            {
+                "street_number": "696",
+                "street_name": "BEAL",
+                "street_type": "PKWY",
+                "post_direction": "NW",
+                "city": "FT WALTON BCH",
+                "region1": "FL",
+                "postal_code": "32547",
+                "full_address": ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547"),
+            },
+        ),
         (
             "xxx, 225 E. John Carpenter Freeway, Suite 1500 Irving, Texas 75062 xxx",
             {
@@ -154,8 +167,8 @@ def test_parse_address(input: str, expected):
     ap = parser.AddressParser(country="US")
     if result := ap.parse(input):
         expected = expected or {}
-        for key in expected:
-            assert getattr(result[0], key) == expected[key]
+        received = {key: getattr(result[0], key) for key in expected}
+        assert expected == received
     else:
         assert expected is None
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -87,6 +87,18 @@ def test_combine_results():
     [
         ("No address here", None),
         (
+            "899 HEATHROW PARK LN 02-2135\nLAKE MARY,FL 32746",
+            {
+                "street_number": "899",
+                "street_name": "HEATHROW PARK",
+                "street_type": "LN",
+                "city": "LAKE MARY",
+                "region1": "FL",
+                "postal_code": "32746",
+                "full_address": "899 HEATHROW PARK LN 02-2135\nLAKE MARY, FL 32746",
+            },
+        ),
+        (
             "696 BEAL PKWY NW\nFT WALTON BCH FL 32547",
             {
                 "street_number": "696",
@@ -96,7 +108,7 @@ def test_combine_results():
                 "city": "FT WALTON BCH",
                 "region1": "FL",
                 "postal_code": "32547",
-                "full_address": ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547"),
+                "full_address": "696 BEAL PKWY NW\nFT WALTON BCH FL 32547",
             },
         ),
         (
@@ -123,7 +135,7 @@ def test_combine_results():
                 "city": "NORTON SHORES",
                 "region1": None,
                 "postal_code": "49441",
-                "full_address": ("1300 E MOUNT GARFIELD ROAD, NORTON SHORES 49441"),
+                "full_address": "1300 E MOUNT GARFIELD ROAD, NORTON SHORES 49441",
             },
         ),
         (

--- a/tests/test_parser_gb.py
+++ b/tests/test_parser_gb.py
@@ -16,7 +16,8 @@ def execute_matching_test(input, expected, pattern):
     match = utils.match(pattern, input, re.VERBOSE)
     is_found = match is not None
     if expected:
-        assert is_found == expected and match.group(0) == input  # type: ignore
+        assert is_found == expected
+        assert match.group(0) == input  # type: ignore
     else:
         assert (is_found == expected) or (match.group(0) != input)  # type: ignore
 
@@ -480,7 +481,7 @@ def test_country(input, expected):
     "input,expected",
     [
         # positive assertions
-        ("11-59 High Road, East Finchley London, N2 8AW", True),
+        ("11-59 High Road\nEast Finchley London\nN2 8AW, UK", True),
         ("88 White parkway, Stanleyton, L2 3DB", True),
         ("Studio 96D, Graham roads, Westtown, L1A 3GP, Great Britain", True),
         ("01 Brett mall, Lake Donna, W02 3JQ", True),

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -469,7 +469,7 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
-        # ("899 HEATHROW PARK LN\nLAKE MARY,FL 32746", True),
+        ("3602 HIGHPOINT\nSAN ANTONIO TX78217", True),
         ("8025 BLACK HORSE\nSTE 300\nPLEASANTVILLE NJ 08232", True),
         ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547", True),
         ("2633 Camino Ramon Ste. 400 San Ramon, CA 94583-2176", True),

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -387,7 +387,10 @@ def test_po_box_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("1806 Dominion Way Ste B", True),
+        ("696 BEAL PKWY", True),
         ("3821 ED DR", True),
+        ("8025 BLACK HOURSE", True),
         ("3525 PIEDMONT RD. NE ST.8-520", True),
         ("140 EAST 45TH, ST, 28TH FLOOR", True),
         ("600 HIGHWAY 32 EAST,", True),
@@ -469,6 +472,8 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("8025 BLACK HORSE\nSTE 300\nPLEASANTVILLE NJ 08232", True),
+        ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547", True),
         ("2633 Camino Ramon Ste. 400 San Ramon, CA 94583-2176", True),
         ("2951 El Camino Real Palo Alto, CA 94306", True),
         ("3821 ED DR, RALEIGH, NC 27612", True),

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -11,14 +11,13 @@ import pyap.source_US.data as data_us
 def execute_matching_test(input, expected, pattern):
     match = utils.match(pattern, input, re.VERBOSE)
     is_found = match is not None
-    if expected:
-        assert is_found == expected and match.group(0) == input  # type: ignore
+    if is_found:
+        if expected:
+            assert match.group(0) == input
+        else:
+            assert match.group(0) != input
     else:
-        """we check that:
-        - input should not to match our regex
-        - our match should be partial if regex matches some part of string
-        """
-        assert (is_found == expected) or (match.group(0) != input)  # type: ignore
+        assert not expected
 
 
 @pytest.mark.parametrize(
@@ -194,7 +193,6 @@ def test_single_street_name(input, expected):
         ("SE", True),
         # negative assertions
         ("NW.", False),
-        ("NW.", False),
         ("NS", False),
         ("EW", False),
     ],
@@ -208,21 +206,19 @@ def test_post_direction(input, expected):
     "input,expected",
     [
         # positive assertions
-        ("Street ", True),
-        ("St. ", True),
+        ("Street", True),
         ("St.", True),
         ("Blvd.", True),
-        ("Blvd. ", True),
-        ("LN ", True),
+        ("LN", True),
         ("RD", True),
         ("Cir", True),
-        ("Highway ", True),
-        ("Hwy ", True),
+        ("Highway", True),
+        ("Hwy", True),
         ("Ct", True),
         ("Sq.", True),
-        ("LP. ", True),
+        ("LP.", True),
         ("LP. (Route A1 )", True),
-        ("Street route 5 ", True),
+        ("Street route 5", True),
         ("blvd", True),
         ("Estate", True),
         ("Manor", True),
@@ -285,12 +281,12 @@ def test_floor(input, expected):
     [
         # positive assertions
         ("Building II", True),
-        ("bldg m ", True),
-        ("Building F ", True),
-        ("bldg 2 ", True),
-        ("building 3 ", True),
-        ("building 100 ", True),
-        ("building 1000 ", True),
+        ("bldg m", True),
+        ("Building F", True),
+        ("bldg 2", True),
+        ("building 3", True),
+        ("building 100", True),
+        ("building 1000", True),
         ("Building ", True),
         ("building one ", True),
         ("Building three ", True),
@@ -311,33 +307,33 @@ def test_building(input, expected):
     [
         # positive assertions
         ("ST.8-520", True),
-        ("suite 900 ", True),
-        ("Suite #2 ", True),
-        ("suite #218 ", True),
-        ("suite J7 ", True),
-        ("suite 102A ", True),
-        ("suite a&b ", True),
-        ("Suite J#200 ", True),
-        ("suite 710-327 ", True),
-        ("Suite A ", True),
-        ("ste A ", True),
-        ("Ste 101 ", True),
-        ("ste 502b ", True),
-        ("ste 14-15 ", True),
-        ("ste E ", True),
-        ("ste 9E ", True),
-        ("Suite 1800 ", True),
-        ("Apt 1B ", True),
-        ("Rm. 52 ", True),
-        ("#2b ", True),
+        ("suite 900", True),
+        ("Suite #2", True),
+        ("suite #218", True),
+        ("suite J7", True),
+        ("suite 102A", True),
+        ("suite a&b", True),
+        ("Suite J#200", True),
+        ("suite 710-327", True),
+        ("Suite A", True),
+        ("ste A", True),
+        ("Ste 101", True),
+        ("ste 502b", True),
+        ("ste 14-15", True),
+        ("ste E", True),
+        ("ste 9E", True),
+        ("Suite 1800", True),
+        ("Apt 1B", True),
+        ("Rm. 52", True),
+        ("#2b", True),
         ("Unit 101", True),
         ("unit 101", True),
         ("#20", True),
         ("Place ", True),
         ("Pl ", True),
-        ("PL. ", True),
+        ("PL.", True),
         ("Place #1200", True),
-        ("Pl #1200 ", True),
+        ("Pl #1200", True),
         ("#1900", True),
         ("#2500C", True),
         ("# 1900", True),
@@ -387,27 +383,28 @@ def test_po_box_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("899 HEATHROW PARK LN", True),
         ("1806 Dominion Way Ste B", True),
         ("696 BEAL PKWY", True),
         ("3821 ED DR", True),
         ("8025 BLACK HOURSE", True),
         ("3525 PIEDMONT RD. NE ST.8-520", True),
         ("140 EAST 45TH, ST, 28TH FLOOR", True),
-        ("600 HIGHWAY 32 EAST,", True),
+        ("600 HIGHWAY 32 EAST", True),
         ("9652 Loiret Boulevard", True),
         ("101 MacIntosh Boulevard", True),
         ("1 West Hegeler Lane", True),
         ("1270 Leeds Avenue", True),
-        ("85-1190 Ranchview Rd. NW ", True),
+        ("85-1190 Ranchview Rd. NW", True),
         ("62 Portland Road (Route 1)", True),
         ("200 N. Pine Avenue Suite 514", True),
         ("200 S. Alloy Drive", True),
         ("Two Hundred S. Alloy Drive", True),
         ("Two Hundred South Alloy Drive", True),
         ("Two Hundred South Alloy Dr.", True),
-        ("11001 Fondren Rd,", True),
+        ("11001 Fondren Rd", True),
         ("9606 North Mopac Expressway Suite 500", True),
-        ("9692 East Arapahoe Road,", True),
+        ("9692 East Arapahoe Road", True),
         ("9 Grand Avenue, Suite 2", True),
         ("9 Grand Avenue Building 2, Suite 2", True),
         ("9 Grand Avenue Building 2, Suite 2A", True),
@@ -440,12 +437,12 @@ def test_po_box_positive(input, expected):
         ("1865 Corporate Dr Ste 225", True),
         ("80 Beaman Rd", True),
         ("9691 Spratley Ave", True),
-        ("10835 New Haven Rd NW ", True),
+        ("10835 New Haven Rd NW", True),
         ("320 W Broussard Rd", True),
         ("9001 Any Old Way", True),
         ("8967 Market St.", True),
         ("3724 Oxford Blvd.", True),
-        ("901 Rainier Ave S ", True),
+        ("901 Rainier Ave S", True),
         ("One Parkway", True),
         ("55 Highpoint", True),
         ("1365 Broadway", True),
@@ -472,6 +469,7 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        # ("899 HEATHROW PARK LN\nLAKE MARY,FL 32746", True),
         ("8025 BLACK HORSE\nSTE 300\nPLEASANTVILLE NJ 08232", True),
         ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547", True),
         ("2633 Camino Ramon Ste. 400 San Ramon, CA 94583-2176", True),


### PR DESCRIPTION
- `\n` is now a priviledged separator, e.g. it cannot appear in places where its not usual to have a line break: e.g street address, city name.
- universalizes the separator logic
- adds a few cases from `myadp` and ensures their correct handling