### PR TITLE
Rework state and postal code matching

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -987,6 +987,7 @@ full_street = r"""
 
 
 def states_abbrvs_regex() -> str:
+    # Some abbreviations are non-standard
     _STATE_ABBRS = {
         "AL",
         "AK",
@@ -1019,7 +1020,7 @@ def states_abbrvs_regex() -> str:
         "NH",
         "NJ",
         "NM",
-        "NY",
+        "NY|N\.Y\.",
         "NC",
         "ND",
         "OH",

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -635,6 +635,7 @@ def test_postal_code(input, expected):
         ("NJ", True),
         ("DC", True),
         ("D.C.", True),
+        ("N.Y.", True),
         ("PuErTO RIco", True),
         ("oregon", True),
         ("Tx", True),

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -476,6 +476,7 @@ def test_full_street_positive(input, expected):
     [
         # positive assertions
         ("P.O. BOX 10323 PH (205) 595-3511\nBIRMINGHAM, AL 35202", True),
+        ("1100 VIRGINIA DR\nFORT WASHINGTON, PA, 19034", True),
         ("3602 HIGHPOINT\nSAN ANTONIO TX78217", True),
         ("8025 BLACK HORSE\nSTE 300\nPLEASANTVILLE NJ 08232", True),
         ("696 BEAL PKWY NW\nFT WALTON BCH FL 32547", True),
@@ -633,17 +634,20 @@ def test_postal_code(input, expected):
         ("Nebraska", True),
         ("NJ", True),
         ("DC", True),
+        ("D.C.", True),
         ("PuErTO RIco", True),
         ("oregon", True),
         ("Tx", True),
         ("nY", True),
         ("fl", True),
         ("MICH", True),
+        # negative assertions
+        ("NJ.", False),
     ],
 )
 def test_region1(input, expected):
     """test exact string match for province"""
-    execute_matching_test(input, expected, data_us.region1)
+    execute_matching_test(input, expected, data_us.make_region1())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Difficult edge case - potential state name is part of city name:
<img width="318" alt="Screenshot 2024-04-25 at 18 25 20" src="https://github.com/argyle-engineering/pyap/assets/51202985/ce1b77eb-82b0-48c4-aa01-1e6dfd8c9b80">

This PR attempts implement the restriction that we should match the state name and postal code each at most one, but requite at least one of the two.
