### PR TITLE
Handle various edge cases around US postal code

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -1172,7 +1172,7 @@ def make_region1_postal_code(
     _postal_code = f"""(?:{part_div}|\-)? {postal_code}"""
     return rf"""
             (?:{_indexed_region1("a")}?{_postal_code}{_indexed_region1("b")}?
-            |{_indexed_region1("c")}(?![-,.\ A-Za-z]{{0,10}}{postal_code_re}))
+            |{_indexed_region1("c")}(?![-,.\sA-Za-z]{{0,10}}{postal_code_re}))
         """
 
 

--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -1154,7 +1154,7 @@ postal_code = rf"""(?P<postal_code>{postal_code_re})"""
 
 country = r"""
             (?:
-                [Uu]\.?[Ss]\.?[Aa]\.?|
+                [Uu]\.?[Ss]\.?(?:[Aa]\.?)?|
                 [Uu][Nn][Ii][Tt][Ee][Dd]\ [Ss][Tt][Aa][Tt][Ee][Ss](?:\ [Oo][Ff]\ [Aa][Mm][Ee][Rr][Ii][Cc][Aa])?
             )
             """
@@ -1171,7 +1171,7 @@ def make_region1_postal_code(
 
     _postal_code = f"""(?:{part_div}|\-)? {postal_code}"""
     return rf"""
-            (?:{_indexed_region1("a")}?{_postal_code}{_indexed_region1("b")}?
+            (?:{_indexed_region1("a")}?(?:{part_div}{country})?{_postal_code}{_indexed_region1("b")}?
             |{_indexed_region1("c")}(?![-,.\sA-Za-z]{{0,10}}{postal_code_re}))
         """
 

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -475,8 +475,10 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("2755 CARPENTER RD SUITE 1W\nANN ARBOR, MI, US, 48108", True),
         ("P.O. BOX 10323 PH (205) 595-3511\nBIRMINGHAM, AL 35202", True),
         ("25 HARBOR PARK DRIVE\nPORT WASHINGTON\nNY 11050", True),
+        ("222 W. Las Colinas Blvd\nSuite 900N\nIrving, Texas, USA 75039-5421", True),
         ("1100 VIRGINIA DR\nFORT WASHINGTON, PA, 19034", True),
         ("3602 HIGHPOINT\nSAN ANTONIO TX78217", True),
         ("8025 BLACK HORSE\nSTE 300\nPLEASANTVILLE NJ 08232", True),

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -476,6 +476,7 @@ def test_full_street_positive(input, expected):
     [
         # positive assertions
         ("P.O. BOX 10323 PH (205) 595-3511\nBIRMINGHAM, AL 35202", True),
+        ("25 HARBOR PARK DRIVE\nPORT WASHINGTON\nNY 11050", True),
         ("1100 VIRGINIA DR\nFORT WASHINGTON, PA, 19034", True),
         ("3602 HIGHPOINT\nSAN ANTONIO TX78217", True),
         ("8025 BLACK HORSE\nSTE 300\nPLEASANTVILLE NJ 08232", True),


### PR DESCRIPTION
- Updated the negative lookahead matcher for postal code
- Handle country in front of the postal code