### PR TITLE
Use official Canadian abbreviations for provinces/territories

### DIFF
--- a/pyap/source_CA/data.py
+++ b/pyap/source_CA/data.py
@@ -480,9 +480,9 @@ region1 = r"""
         (?P<region1>
             (?:
                 # province abbreviations (English)
-                A\.?B\.?|B\.?C\.?|M\.?B\.?|N\.?B\.?|N\.?L\.?|
-                N\.?T\.?|N\.?S\.?|N\.?U\.?|O\.?N\.?|P\.?E\.?|
-                Q\.?C\.?|S\.?K\.?|Y\.?T\.?
+                AB\b|Alta\.|BC\b|B\.C\.|MB\b|Man\.|NB\b|N\.B\.|NL/b|N\.L\.|
+                NT\b|N\.W\.T\.|NS\b|N\.S\.|NU\b|Nvt\.|ON\b|Ont\.|PE\b|P\.E\.I\.|
+                QC\b|Que\.|SK\b|Sask\.|YT\b|Y\.T\.
             )
             |
             (?:

--- a/tests/test_parser_ca.py
+++ b/tests/test_parser_ca.py
@@ -366,6 +366,7 @@ still finding correct matches in full_address
         ("15979 Bow Bottom Trail SE, Calgary, AB T2J 6T5", True),
         ("1730 McPherson Crt. Unit 35, Pickering, ON", True),
         ("20 Fleeceline Road, Toronto, Ontario M8V 2K3", True),
+        ("5090 ORBITOR DRIVE SUITE 1, MISSISSAUGA ONTARIO L4W 5B5", True),
         ("7034 Gilliespie Lane, Mississauga, ON L5W1E8", True),
         ("12991 Keele Street King City, Ontario L7B 1G2 CANADA", True),
         ("15979 Bow Bottom Trail SE, Calgary, AB T2J 6T5", True),


### PR DESCRIPTION
Updates matcher for Canadian provinces and territories to only use [official abbreviations](https://www12.statcan.gc.ca/census-recensement/2021/ref/dict/tab/index-eng.cfm?ID=t1_8). Also, abbreviations should require word boundary so that we don't only match "ON" in "ONTARIO".