### PR TITLE
Support one-letter avenue names

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -127,7 +127,7 @@ street_name_multi_word_re = r"""
 
 # This pattern should be quite conservative because it will be followed by
 # optional matchers - we want to avoid matching too much with this.
-street_name_one_word_re = r"(?:[A-Z][A-Za-z]{2,15})"
+street_name_one_word_re = r"(?:[A-Z][A-Za-z]{,15})"
 
 
 interstate_specs = [
@@ -769,7 +769,7 @@ street_type_list = [
     "Xrds",
 ]
 
-street_type_leading_list = ["Camino", "El\ Camino"]
+street_type_leading_list = ["Camino", "El\ Camino", "Avenue"]
 
 
 def street_type_list_to_regex(street_type_list: list[str]) -> str:

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -493,6 +493,7 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("1234 Avenue N, Rosenberg, Texas 77777", True),
         ("One Baylor Plaza MS: BCM204\nHouston TX 77030-3411", True),
         ("ONE ADP DRIVE\nMS CORP 003\nAUGUSTA, GA 30909", True),
         ("2755 CARPENTER RD SUITE 1W\nANN ARBOR, MI, US, 48108", True),


### PR DESCRIPTION
`Avenue I` and `Avenue N` are legitimate street names - this PR adds support for these.