### PR TITLE
Add `Bay` street type

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -211,7 +211,7 @@ post_direction = r"""
 )
 
 # This list was taken from: https://pe.usps.com/text/pub28/28apc_002.htm
-# Broadway and Lp (abbreviation for Loop) were added to the list
+# Bay, Broadway and Lp (abbreviation for Loop) were added to the list
 street_type_list = [
     "Allee",
     "Alley",
@@ -230,6 +230,7 @@ street_type_list = [
     "Avenue",
     "Avn",
     "Avnue",
+    "Bay",
     "Bayoo",
     "Bayou",
     "Bch",

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -228,6 +228,7 @@ def test_post_direction(input, expected):
         ("Interstate 35", True),
         ("I- 35", True),
         ("I-35 Service Road", True),
+        ("BAY", True),
         # negative assertions
         # TODO
     ],
@@ -601,6 +602,7 @@ def test_full_street_positive(input, expected):
         ("2006 Broadway Ave Suite 2A, PO Drawer J, Great Bend, KS 67530", True),
         ("135 Pinelawn Road STE 130 S, Melville, NY 11747", True),
         ("1800 M STREET NW SUITE 375 N, WASHINGTON, DC 20036", True),
+        ("10 INDIAN BAY, ALAMEDA CA 94502", True),
         # negative assertions
         ("ONE HEALING CENTER LLC, 16444", False),
         ("85 STEEL REGULAR SHAFT - NE", False),


### PR DESCRIPTION
This PR adds `Bay` as another street type.

For example : `107 INDIAN BAY`, which is a legitimate address (see on [Maps](https://maps.app.goo.gl/U6kksLdUpBpP1ChS6)).

It is also valid for [USPS address tool](https://tools.usps.com/zip-code-lookup.htm?byaddress) :
![Screenshot 2024-09-17 at 11 24 15](https://github.com/user-attachments/assets/0e77e28d-941b-46b3-bb72-56485e03eb3c)
