### PR TITLE
Fix bay occupancy

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -230,7 +230,7 @@ street_type_list = [
     "Avenue",
     "Avn",
     "Avnue",
-    "Bay",
+    "Bay(?!\ [1-9])",
     "Bayoo",
     "Bayou",
     "Bch",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -207,6 +207,18 @@ def test_combine_results():
                 "postal_code": "77030-3411",
             },
         ),
+        (
+            "2817 PETERS ROAD BAY 52, Amazeville, AL 12345",
+            {
+                "street_number": "2817",
+                "street_type": "ROAD",
+                "street_name": "PETERS",
+                "occupancy": "BAY 52",
+                "city": "Amazeville",
+                "region1": "AL",
+                "postal_code": "12345",
+            },
+        ),
     ],
 )
 def test_parse_address(input: str, expected):

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -482,6 +482,7 @@ def test_po_box_positive(input, expected):
         ("P.O. BOX 41256, One Velvet Drive", True),
         ("666 Hell ST PMB 29700", True),
         ("817 S.E. 55TH", True),
+        ("2817 PETERS ROAD BAY 52", True),
         # negative assertions
         (", 666 Hell ST PMB 29700", False),
     ],


### PR DESCRIPTION
`Bay` can be matched as a street type as well as occupancy. If it's followed by a digit we assume it's part of occupancy:
<img width="293" alt="Screenshot 2024-10-09 at 15 25 01" src="https://github.com/user-attachments/assets/8b3dadac-07e8-4235-b6ea-ae6371522dcb">

