### PR TITLE
Support Pk as street type

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -572,6 +572,7 @@ street_type_list = [
     "Pikes",
     "Pine",
     "Pines",
+    "Pk",
     "Pkway",
     "Pkwy",
     "Pkwys",

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -207,6 +207,7 @@ def test_post_direction(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("PK", True),
         ("Street", True),
         ("St.", True),
         ("Blvd.", True),
@@ -497,6 +498,7 @@ def test_full_street_positive(input, expected):
     "input,expected",
     [
         # positive assertions
+        ("2222 WASHINGTON PK SUITE 401  BRIDGEVILLE, PA 11111", True),
         ("1234 Avenue N, Rosenberg, Texas 77777", True),
         ("One Baylor Plaza MS: BCM204\nHouston TX 77030-3411", True),
         ("ONE ADP DRIVE\nMS CORP 003\nAUGUSTA, GA 30909", True),


### PR DESCRIPTION
Adds "Pk", short for "Pike", as supported street type, [example](https://lookups.melissa.com/home/addresscheck/address/?address=1225+WASHINGTON+PK+SUITE+401++BRIDGEVILLE%2C+PA+15017+&suites=&freeForm=&mak=&checkOption=append)