### PR TITLE
Bump workflow versions

### DIFF
--- a/.github/workflows/pr-publish-to-test-pypi.yml
+++ b/.github/workflows/pr-publish-to-test-pypi.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build Python package
       run: poetry build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Build Python package
       run: poetry build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@4
       with:
         name: python-package-distributions
         path: dist/
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -67,7 +67,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
`actions@v3` is not supported anymore by GH