### PR TITLE
US address parsing fixes

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -85,6 +85,7 @@ Street number can be written 2 ways:
    a) - "1022"
    b) - "85-1190"
    c) - "85 1190"
+   d) - 5214F
 """
 street_number = r"""(?P<street_number>
                         \b(?:
@@ -99,7 +100,7 @@ street_number = r"""(?P<street_number>
                             {ten_to_ninety}
                         ){from_to}
                         |
-                        (?:\b\d{from_to}(?:\-(?:\d{from_to}|[A-Z]))?\ )
+                        (?:\b\d{from_to}(?:\-?(?:\d{from_to}|[A-Z]))?\ )
                     )
                 """.format(
     thousand=thousand,
@@ -247,6 +248,7 @@ street_type_list = [
     "Bend",
     "Bg",
     "Bgs",
+    "Bl",
     "Blf",
     "Blfs",
     "Bluf",
@@ -988,7 +990,7 @@ full_street = r"""
                 (?:{space_div}{post_direction})?
                 (?:{part_div}{floor})?
                 (?:{part_div}{building})?
-                (?:{part_div}{occupancy})?
+                (?:{part_div}?{occupancy})?
                 (?:{part_div}{mail_stop})?
                 (?:{part_div}(?P<po_box_a>{po_box}))?
             )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,7 +1,7 @@
 # pyright: reportPrivateUsage=false
 # -*- coding: utf-8 -*-
 
-""" Test for parser classes """
+"""Test for parser classes"""
 
 import pytest
 from pyap import parser, exceptions, address, parse, parse_single_street
@@ -218,6 +218,30 @@ def test_combine_results():
                 "city": "Amazeville",
                 "region1": "AL",
                 "postal_code": "12345",
+            },
+        ),
+        (
+            "6325F OPAL HEIGHTS BL\nSAN FRANCISCO CA 94131",
+            {
+                "street_number": "6325F",
+                "street_type": "BL",
+                "street_name": "OPAL HEIGHTS",
+                "occupancy": None,
+                "city": "SAN FRANCISCO",
+                "region1": "CA",
+                "postal_code": "94131",
+            },
+        ),
+        (
+            "2744W GRANDIOSE WAY#100\nLEHI UT 84043",
+            {
+                "street_number": "2744W",
+                "street_type": "WAY",
+                "street_name": "GRANDIOSE",
+                "occupancy": "#100",
+                "city": "LEHI",
+                "region1": "UT",
+                "postal_code": "84043",
             },
         ),
     ],

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -125,6 +125,7 @@ def test_thousand(input, expected):
         ("32457 ", True),
         ("155-B ", True),
         ("25-C ", True),
+        ("5214F ", True),
         # negative assertions (words)
         ("ONE THousszz22and FIFTY and four onde", False),
         ("ONE one oNe and onE Three", False),


### PR DESCRIPTION
* Handles street number without the dash inbetween numbers and letter
* Adds `Bl` street type
* Adds separator between street type and occupancy as optional, often the street type are as `WAY#100` without the separator