### PR TITLE
stricter numbered highway parsing

### DIFF
--- a/pyap/source_US/data.py
+++ b/pyap/source_US/data.py
@@ -110,74 +110,80 @@ street_number = r"""(?P<street_number>
     from_to="{1,5}",
 )
 
+STATE_ABBRS = (
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    r"MI(?:CH)?\.?",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    r"NY|N\.Y\.",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+)
+
+# Some abbreviations are non-standard.
+NON_STATE_ABBRS = (
+    "AS",
+    "GU",
+    "MP",
+    "PR",
+    "VI",
+    r"D\.?C\.?",
+)
+
 
 def states_abbrvs_regex() -> str:
-    # Some abbreviations are non-standard
-    _STATE_ABBRS = {
-        "AL",
-        "AK",
-        "AZ",
-        "AR",
-        "CA",
-        "CO",
-        "CT",
-        "DE",
-        "FL",
-        "GA",
-        "HI",
-        "ID",
-        "IL",
-        "IN",
-        "IA",
-        "KS",
-        "KY",
-        "LA",
-        "ME",
-        "MD",
-        "MA",
-        "MI(?:CH)?\.?",
-        "MN",
-        "MS",
-        "MO",
-        "MT",
-        "NE",
-        "NV",
-        "NH",
-        "NJ",
-        "NM",
-        "NY|N\.Y\.",
-        "NC",
-        "ND",
-        "OH",
-        "OK",
-        "OR",
-        "PA",
-        "RI",
-        "SC",
-        "SD",
-        "TN",
-        "TX",
-        "UT",
-        "VT",
-        "VA",
-        "WA",
-        "WV",
-        "WI",
-        "WY",
-    }
-    _NON_STATE_ABBRS = {
-        "AS",
-        "GU",
-        "MP",
-        "PR",
-        "VI",
-        "D\.?C\.?",
-    }
     return (
         r"(?:"
-        + str_list_to_upper_lower_regex(list(_STATE_ABBRS | _NON_STATE_ABBRS))
+        + str_list_to_upper_lower_regex(list(STATE_ABBRS + NON_STATE_ABBRS))
         + r")(?![A-Za-z])"
     )
+
+
+def state_highway_abbrvs_regex() -> str:
+    return r"(?:" + "|".join(STATE_ABBRS + NON_STATE_ABBRS) + r")(?![A-Za-z])"
 
 
 """
@@ -265,7 +271,7 @@ numbered_alternate = (
 # Some states name their state-maintained highways by the state abbreviation
 # and the number.
 numbered_state_highway = r"""(?:{states}\ \d{{1,4}}(?!\d))""".format(
-    states=states_abbrvs_regex()
+    states=state_highway_abbrvs_regex()
 )
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -34,6 +34,17 @@ def test_api_parse_single_street():
     assert str(addresses[0].full_address) == "255 SOUTH STREET"
 
 
+def test_api_parse_single_street_skips_mixed_case_state_highway_false_positive():
+    test_address = (
+        "Hilmar Cheese Company, Inc.\n"
+        "Plies: aR 8901 North Lander Avenue\n"
+        "ANY\n"
+        "2-CHEESE COMPANY No Hilmar, California 95324"
+    )
+    addresses = parse_single_street(test_address, country="US")
+    assert str(addresses[0].full_street) == "8901 North Lander Avenue"
+
+
 def test_address_class_init():
     addr = address.Address(
         country_id="US",

--- a/tests/test_parser_us.py
+++ b/tests/test_parser_us.py
@@ -178,7 +178,9 @@ def test_street_name(input, expected):
         ("W. STATE ROAD 123", True),
         ("Alt 123", True),
         ("Alternate 123", True),
+        ("NC 54", True),
         # negative assertions
+        ("nC 54", False),
     ],
 )
 def test_numbered_or_typeless_street_name(input, expected):


### PR DESCRIPTION
make the state highway matcher case sensitive as it's a little broad, to avoid matching ocr artifacts