### PR TITLE
add occupancy-first format for Canada

### DIFF
--- a/pyap/source_CA/data.py
+++ b/pyap/source_CA/data.py
@@ -377,6 +377,17 @@ occupancy = r"""
             )\ ?
             """
 
+unit_first_civic = r"""
+            (?:
+                (?<![\.0-9])
+                \#?
+                (?P<occupancy_c>\d{1,4})
+                \ ?\-\ ?
+                (?P<street_number_c>\d{1,5})
+                (?=[\ ,\n])\ ?
+            )
+            """
+
 po_box = r"""
             (?:
                 # English - PO Box 123
@@ -444,7 +455,7 @@ full_street = r"""
         (?P<full_street>
 
             (?P<line1>
-                {street_number}\,?\ ?
+                (?:{unit_first_civic}|{street_number})\,?\ ?
                 {street_name}?\,?\ ?
                 (?:(?<=[\ \,]){street_type})\,?\ ?
                 {post_direction}?
@@ -476,6 +487,7 @@ full_street = r"""
     floor=floor,
     building=building,
     occupancy=occupancy,
+    unit_first_civic=unit_first_civic,
     po_box=po_box,
     po_box_b=po_box_b,
     po_box_positive_lookahead=po_box_positive_lookahead,

--- a/tests/test_parser_ca.py
+++ b/tests/test_parser_ca.py
@@ -314,6 +314,44 @@ def test_occupancy_negative(input, expected):
 
 
 @pytest.mark.parametrize(
+    "input,occupancy,street_number",
+    [
+        ("200 - 5050 ", "200", "5050"),
+        ("108 - 1550 ", "108", "1550"),
+        ("202-121 ", "202", "121"),
+        ("104-18663 ", "104", "18663"),
+        ("#4-123 ", "4", "123"),
+    ],
+)
+def test_unit_first_civic_positive(input, occupancy, street_number):
+    """tests string match for the occupancy-first civic number format"""
+    match = utils.match(
+        data_ca.unit_first_civic, utils.unicode_str(input), re.VERBOSE
+    )
+    assert match is not None
+    assert match.group("occupancy_c") == occupancy
+    assert match.group("street_number_c") == street_number
+
+
+@pytest.mark.parametrize(
+    "input,expected",
+    [
+        # negative assertions
+        ("718 - 8th ", False),
+        ("108-1550x ", False),
+        ("suite 900 ", False),
+    ],
+)
+def test_unit_first_civic_negative(input, expected):
+    """tests string match for the occupancy-first civic number format"""
+    match = utils.match(
+        data_ca.unit_first_civic, utils.unicode_str(input), re.VERBOSE
+    )
+    is_found = match is not None
+    assert is_found == expected
+
+
+@pytest.mark.parametrize(
     "input,expected",
     [
         # positive assertions


### PR DESCRIPTION
Canada Post suggests the [preferred format](https://www.canadapost-postescanada.ca/cpc/en/support/articles/addressing-guidelines/civic-address.page) for occupancy numbers is prefixed before the street address with a hyphen, so this adds occupancy parsing in that location as well for Canadian addresses. 